### PR TITLE
Fix pickup point select in Paypal Checkout

### DIFF
--- a/includes/class-itella-shipping.php
+++ b/includes/class-itella-shipping.php
@@ -217,6 +217,7 @@ class Itella_Shipping
     $this->loader->add_action('woocommerce_order_details_after_order_table', $plugin_public, 'show_pp_details', 10, 1);
     $this->loader->add_action('woocommerce_checkout_update_order_meta', $plugin_public, 'add_pp_id_to_order');
     $this->loader->add_action('woocommerce_order_status_completed', $plugin_public, 'show_pp');
+    $this->loader->add_action('woocommerce_checkout_before_order_review', $plugin_public, 'itella_checkout_hidden_fields');
 
     $this->loader->add_filter('woocommerce_package_rates', $plugin_public, 'show_itella_shipping_methods', 10, 1);
   }

--- a/public/class-itella-shipping-public.php
+++ b/public/class-itella-shipping-public.php
@@ -186,4 +186,22 @@ class Itella_Shipping_Public
     return $methods;
   }
 
+  /**
+   * Add hidden fields
+  */
+  public function itella_checkout_hidden_fields()
+  {
+    // fix for Paypal Checkout page
+    $ship_country = WC()->customer->get_shipping_country();
+    if ( function_exists('wc_gateway_ppec') ) {
+      $token = $_GET['token'];
+      $client   = wc_gateway_ppec()->client;
+      $response = $client->get_express_checkout_details( $token );
+      if ( isset($response['SHIPTOCOUNTRYCODE']) ) {
+        $ship_country = $response['SHIPTOCOUNTRYCODE'];
+      }
+    }
+    echo '<input type="hidden" id="itella_shipping_country" value="' . $ship_country . '">';
+  }
+
 }

--- a/public/js/itella-shipping-public.js
+++ b/public/js/itella-shipping-public.js
@@ -32,7 +32,9 @@ function itella_init() {
         .setCountry(
             document.querySelector('#billing_country') ?
             document.querySelector('#billing_country').value :
-            document.querySelector('#calc_shipping_country').value
+            ( document.querySelector('#calc_shipping_country') ?
+              document.querySelector('#calc_shipping_country').value :
+              document.querySelector('#itella_shipping_country').value )
         )
         .setLocations(terminals, true)
         .registerCallback(function (manual) {


### PR DESCRIPTION
Added hidden country field, which is used when other country fields not exist. This issue fix pickup point selection in Paypal Checkout page, when country field not exist. Also in Paypal Checkout, country value is obtained from Paypal response.