### PR TITLE
Fix validate_pickup_point if only digital products in cart

### DIFF
--- a/admin/class-itella-shipping-method.php
+++ b/admin/class-itella-shipping-method.php
@@ -1261,7 +1261,8 @@ class Itella_Shipping_Method extends WC_Shipping_Method
    */
   public function validate_pickup_point()
   {
-    $isItellaPp = in_array('itella_pp',wc_clean($_POST['shipping_method']));
+		$shipping_method = (isset($_POST['shipping_method']) && is_array($_POST['shipping_method'])) ? wc_clean($_POST['shipping_method']) : [];
+    $isItellaPp = in_array('itella_pp',$shipping_method);
     if ($isItellaPp && empty($_POST['itella-chosen-point-id'])) {
       wc_add_notice( __( "You must choose Smartpost Pickup Point", 'itella-shipping' ), 'error');
     }


### PR DESCRIPTION
If only digital products in cart there are no shipping methods to check. 

Fixes error:
PHP Fatal error:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in /wp-content/plugins/itella-shipping/admin/class-itella-shipping-method.php:1258