### PR TITLE
Fix empty Itella API call return for specific country 

### DIFF
--- a/admin/class-itella-shipping-method.php
+++ b/admin/class-itella-shipping-method.php
@@ -217,8 +217,10 @@ class Itella_Shipping_Method extends WC_Shipping_Method
         
         if ( ! empty($locations) ) {
           $itella_pickup_points_obj->saveLocationsToJSONFile($filename, json_encode($locations));
-        }
-      }
+        } else {
+	  // No data was returned for the country, save empty JSON
+	  file_put_contents($filename, json_encode([]));
+      	}
     }
   }
 


### PR DESCRIPTION
Fix issue when Itella API does not return any pickup points for the country. Instead of saving empty file, save file with empty JSON so the file is not 0kb in size.